### PR TITLE
fix: ブログのカテゴリーを指定して、その後、カテゴリー選択なしにしても新着情報は古いカテゴリーを指定しているバグ修正

### DIFF
--- a/Model/Behavior/TopicsBaseBehavior.php
+++ b/Model/Behavior/TopicsBaseBehavior.php
@@ -306,7 +306,12 @@ class TopicsBaseBehavior extends ModelBehavior {
 			$pathKey = $setting[$field];
 		}
 
-		if (array_key_exists($field, $data) || Hash::get($model->data, $pathKey) !== null) {
+		list($modleByData, $fieldByData) = pluginSplit($pathKey);
+
+		if (array_key_exists($field, $data) ||
+				isset($model->data[$modleByData]) &&
+					array_key_exists($fieldByData, $model->data[$modleByData]) ||
+				Hash::get($model->data, $pathKey) !== null) {
 			return true;
 		} else {
 			return false;
@@ -332,8 +337,13 @@ class TopicsBaseBehavior extends ModelBehavior {
 			$pathKey = $setting[$field];
 		}
 
+		list($modleByData, $fieldByData) = pluginSplit($pathKey);
+
 		if (array_key_exists($field, $data)) {
 			return Hash::get($data, $field);
+		} elseif (isset($model->data[$modleByData]) &&
+					array_key_exists($fieldByData, $model->data[$modleByData])) {
+			return $model->data[$modleByData][$fieldByData];
 		} elseif (Hash::get($model->data, $pathKey, false) !== false) {
 			return Hash::get($model->data, $pathKey);
 		} else {


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/1652